### PR TITLE
Document the needed version for rsa package in Juniper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ site-configuration-client==0.1.4
 social-auth-app-django==3.3.0 ; python_version <= "3.5"
 python-jose==3.2.0 ; python_version <= "3.5"
 requests==2.23.0 ; python_version <= "3.5"
+rsa==4.7.2 ; python_version <= "3.5"
 
 # Open edX requirements: Koa
 social-auth-app-django==4.0.0 ; python_version >= "3.8"


### PR DESCRIPTION
## Change description

Document the needed version for rsa package in Juniper

`rsa` is an unused dependency of `python-jose`. It's not pinned when installing `python-jose==3.2.0` for Python 3.5. Therefore; the latest `rsa` with no Python 3.5 support will be pulled, and a version conflict error will be raised


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
