### PR TITLE
login via magiclink (broken)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ social-auth-app-django==4.0.0 ; python_version >= "3.8"
 python-jose==3.3.0 ; python_version >= "3.8"
 requests==2.25.0 ; python_version >= "3.8"
 
+# Magiclink for Studio authentication until Maple
+django-magiclink==1.2.0
+
 # Test requirements
 # Those may break, when they do, pin them.
 django-coverage-plugin

--- a/tahoe_idp/apps.py
+++ b/tahoe_idp/apps.py
@@ -14,7 +14,25 @@ class TahoeIdpConfig(AppConfig):
             "lms.djangoapp": {
                 "namespace": "tahoe_idp",
                 "regex": "^tahoe-idp/api/v1/",
-            }
+            },
+            "cms.djangoapp": {
+                # TODO: Only include `path('login/', Login.as_view(), name='login'),` to avoid including signups
+                "namespace": "magiclink",
+                "app_name": "magiclink",
+                "regex": "^auth_link/",
+            },
+        },
+        "settings_config": {
+            "lms.djangoapp": {
+                "common": {
+                    "relative_path": "settings.common",
+                },
+            },
+            "cms.djangoapp": {
+                "common": {
+                    "relative_path": "settings.cms",
+                },
+            },
         },
     }
 

--- a/tahoe_idp/settings/cms.py
+++ b/tahoe_idp/settings/cms.py
@@ -1,0 +1,16 @@
+from . import common
+
+
+def plugin_settings(settings):
+    common.plugin_settings(settings)
+    settings.AUTHENTICATION_BACKENDS = [
+        'magiclink.backends.MagicLinkBackend'
+    ] + settings.AUTHENTICATION_BACKENDS
+
+    settings.MAGICLINK_REQUIRE_SIGNUP = True
+    settings.MAGICLINK_LOGIN_FAILED_REDIRECT = '/'  # TODO: Make a better page
+    settings.LOGIN_REDIRECT_URL = '/home'
+
+    settings.MAGICLINK_ALLOW_SUPERUSER_LOGIN = False
+    settings.MAGICLINK_ALLOW_STAFF_LOGIN = False
+

--- a/tahoe_idp/settings/common.py
+++ b/tahoe_idp/settings/common.py
@@ -1,0 +1,4 @@
+
+
+def plugin_settings(settings):
+    settings.INSTALLED_APPS += ['magiclink']

--- a/tahoe_idp/urls.py
+++ b/tahoe_idp/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from tahoe_idp.views import RegistrationAPIView, RegistrationView
+from .views import RegistrationAPIView, RegistrationView, StudioLogin
 
 urlpatterns = [
     path("register", RegistrationAPIView.as_view(), name="register_api"),
+    path("studio", StudioLogin.as_view(), name="studio_idp_login"),
     # TODO: remove when not necessary
     path("signup", RegistrationView.as_view(), name="register_view"),
 ]


### PR DESCRIPTION
Similar to Slacks magic link login.

Using https://github.com/pyepye/django-magiclink (only python3.6 compatible)

Workflow:

 - Go to LMS mysite.tahoe.appsembler.com/studio
 - a one-time login URL gets generated: studio.tahoe.appsembler.com/log_me_in/7962fa9e-c88d-11ec&email=me@site.com
 - the user is logged in into Studio