### PR TITLE
bump to 1.0.0 for fusionauth

### DIFF
--- a/tahoe_idp/__init__.py
+++ b/tahoe_idp/__init__.py
@@ -4,4 +4,4 @@ tahoe_idp initialization module
 
 # Increase this version by 1 after every backward-incompatible
 # change in the exported data format
-__version__ = "0.1.0-dev4"
+__version__ = "1.0.0"


### PR DESCRIPTION
bump to 1.0.0 for backward incompatible changes.