### PR TITLE
fullname fallback to username

### DIFF
--- a/tahoe_idp/backend.py
+++ b/tahoe_idp/backend.py
@@ -59,19 +59,14 @@ class TahoeIdpOAuth2(BaseOAuth2):
         tahoe_idp_uuid = response["userId"]
         idp_user = helpers.fusionauth_retrieve_user(tahoe_idp_uuid)
 
-        first_name = idp_user["firstName"]
-        last_name = idp_user["lastName"]
-        fullname = "{first_name} {last_name}".format(first_name=first_name, last_name=last_name)
-
         user_data = idp_user.get("data", {})
         user_data_role = get_role_with_default(user_data)
+        username = idp_user.get("username", idp_user["id"])
 
         return {
-            "username": idp_user.get("username", idp_user["id"]),
+            "username": username,
             "email": idp_user["email"],
-            "fullname": fullname,
-            "first_name": first_name,
-            "last_name": last_name,
+            "fullname": idp_user.get("fullName", username),
             "tahoe_idp_uuid": idp_user["id"],
             "tahoe_idp_is_organization_admin": is_organization_admin(user_data_role),
             "tahoe_idp_is_organization_staff": is_organization_staff(user_data_role),

--- a/tahoe_idp/tests/test_backend.py
+++ b/tahoe_idp/tests/test_backend.py
@@ -129,11 +129,9 @@ class TahoeIdPBackendTest(OAuth2Test):
     def test_get_user_details(self, mock_get_idp_user):
         mock_get_idp_user.return_value = {
             "email": "ahmed@appsembler.com",
-            "firstName": "Ahmed",
+            "fullName": "Ahmed Jazzar",
             "id": "2a106a94-c8b0-4f0b-bb69-fea0022c18d8",
-            "lastName": "Jazzar",
             "tenantId": "aa4a50e3-0d57-d047-6618-0aea1efadf74",
-            "username": "ahmedjazzar",
             "data": {
                 "platform_role": "Staff",
             }
@@ -144,11 +142,9 @@ class TahoeIdPBackendTest(OAuth2Test):
         })
 
         assert user_details == {
-            "username": "ahmedjazzar",
+            "username": "2a106a94-c8b0-4f0b-bb69-fea0022c18d8",  # Username not provided, using UUID as username
             "email": "ahmed@appsembler.com",
             "fullname": "Ahmed Jazzar",
-            "first_name": "Ahmed",
-            "last_name": "Jazzar",
             "tahoe_idp_uuid": "2a106a94-c8b0-4f0b-bb69-fea0022c18d8",
             "tahoe_idp_is_organization_admin": False,
             "tahoe_idp_is_organization_staff": True,
@@ -163,9 +159,7 @@ class TahoeIdPBackendTest(OAuth2Test):
         """
         mock_get_idp_user.return_value = {
           "email": "ahmed@appsembler.com",
-          "firstName": "Ahmed",
           "id": "2a106a94-c8b0-4f0b-bb69-fea0022c18d8",
-          "lastName": "Jazzar",
           "tenantId": "aa4a50e3-0d57-d047-6618-0aea1efadf74",
           "username": "ahmedjazzar",
         }
@@ -177,9 +171,7 @@ class TahoeIdPBackendTest(OAuth2Test):
         assert user_details == {
             "username": "ahmedjazzar",
             "email": "ahmed@appsembler.com",
-            "fullname": "Ahmed Jazzar",
-            "first_name": "Ahmed",
-            "last_name": "Jazzar",
+            "fullname": "ahmedjazzar",  # fullNAme not provided, using `username` as full name
             "tahoe_idp_uuid": "2a106a94-c8b0-4f0b-bb69-fea0022c18d8",
             "tahoe_idp_is_organization_admin": False,
             "tahoe_idp_is_organization_staff": False,


### PR DESCRIPTION
FusionAuth can return a ton of missing information.
