### PR TITLE
fix exception in cms due to missing THIRD_PARTY_AUTH_BACKENDS

### DIFF
--- a/tahoe_idp/apps.py
+++ b/tahoe_idp/apps.py
@@ -20,12 +20,12 @@ class TahoeIdpConfig(AppConfig):
         'settings_config': {
             'lms.djangoapp': {
                 'production': {
-                    'relative_path': 'settings.production',
+                    'relative_path': 'settings.lms_production',
                 },
             },
             'cms.djangoapp': {
                 'production': {
-                    'relative_path': 'settings.production',
+                    'relative_path': 'settings.cms_production',
                 },
             },
         },

--- a/tahoe_idp/settings/cms_production.py
+++ b/tahoe_idp/settings/cms_production.py
@@ -1,0 +1,14 @@
+"""
+CMS/Studio settings.
+"""
+
+from .common_production import magiclink_settings
+
+
+def plugin_settings(settings):
+    magiclink_settings(settings)
+
+    # MagicLinkBackend should be the first used backend
+    magiclink_backend = 'tahoe_idp.magiclink_backends.MagicLinkBackend'
+    if magiclink_backend not in settings.AUTHENTICATION_BACKENDS:
+        settings.AUTHENTICATION_BACKENDS.insert(0, magiclink_backend)

--- a/tahoe_idp/settings/common_production.py
+++ b/tahoe_idp/settings/common_production.py
@@ -1,4 +1,7 @@
-# fdddlake8: nodddqa: E501
+"""
+Common production settings.
+"""
+
 from django.core.exceptions import ImproperlyConfigured
 
 
@@ -45,17 +48,3 @@ def magiclink_settings(settings):
     settings.MAGICLINK_STUDIO_DOMAIN = getattr(settings, 'MAGICLINK_STUDIO_DOMAIN', 'studio.example.com')
 
     settings.MAGICLINK_STUDIO_PERMISSION_METHOD = getattr(settings, 'MAGICLINK_STUDIO_PERMISSION_METHOD', None)
-
-    # MagicLinkBackend should be the first used backend
-    magiclink_backend = 'tahoe_idp.magiclink_backends.MagicLinkBackend'
-    if magiclink_backend not in settings.AUTHENTICATION_BACKENDS:
-        settings.AUTHENTICATION_BACKENDS.insert(0, magiclink_backend)
-
-
-def plugin_settings(settings):
-    magiclink_settings(settings)
-
-    # Add the Social / ThirdPartyAuth backend
-    tahoe_idp_backend = 'tahoe_idp.backend.TahoeIdpOAuth2'
-    if tahoe_idp_backend not in settings.THIRD_PARTY_AUTH_BACKENDS:
-        settings.THIRD_PARTY_AUTH_BACKENDS.insert(0, tahoe_idp_backend)

--- a/tahoe_idp/settings/lms_production.py
+++ b/tahoe_idp/settings/lms_production.py
@@ -1,0 +1,14 @@
+"""
+LMS Settings.
+"""
+
+from .common_production import magiclink_settings
+
+
+def plugin_settings(settings):
+    magiclink_settings(settings)
+
+    # Add the Social / ThirdPartyAuth backend
+    tahoe_idp_backend = 'tahoe_idp.backend.TahoeIdpOAuth2'
+    if tahoe_idp_backend not in settings.THIRD_PARTY_AUTH_BACKENDS:
+        settings.THIRD_PARTY_AUTH_BACKENDS.insert(0, tahoe_idp_backend)

--- a/tahoe_idp/tests/test_apps.py
+++ b/tahoe_idp/tests/test_apps.py
@@ -10,23 +10,23 @@ def test_app_config():
         'settings_config': {
             'cms.djangoapp': {
                 'production': {  # Needs to be production settings, otherwise devstack will override it
-                    'relative_path': 'settings.production'
+                    'relative_path': 'settings.cms_production',  # Use cms-settings
                 },
             },
             'lms.djangoapp': {
                 'production': {  # Needs to be production settings, otherwise devstack will override it
-                    'relative_path': 'settings.production'
+                    'relative_path': 'settings.lms_production',  # Use lms-settings
                 },
-            }
+            },
         },
         'url_config': {
             'cms.djangoapp': {
                 'namespace': 'tahoe_idp',
-                'app_name': 'tahoe_idp'
+                'app_name': 'tahoe_idp',
             },
             'lms.djangoapp': {
                 'namespace': 'tahoe_idp',
-                'app_name': 'tahoe_idp'
-            }
-        }
+                'app_name': 'tahoe_idp',
+            },
+        },
     }, 'Should initiate the app as an Open edX plugin.'

--- a/tahoe_idp/tests/test_openedx_settings.py
+++ b/tahoe_idp/tests/test_openedx_settings.py
@@ -4,34 +4,38 @@ Tests for the openedx production.py settings.
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
-from tahoe_idp.settings.production import plugin_settings
+from tahoe_idp.settings import (
+    cms_production,
+    common_production,
+    lms_production,
+)
 
 
-def test_tpa_backend_settings(settings):
+def test_lms_tpa_backend_settings(settings):
     """
     Test settings third party auth backends.
     """
     settings.THIRD_PARTY_AUTH_BACKENDS = ['dummy_backend']
-    plugin_settings(settings)
+    lms_production.plugin_settings(settings)
 
     backend_path = 'tahoe_idp.backend.TahoeIdpOAuth2'
     assert backend_path == settings.THIRD_PARTY_AUTH_BACKENDS[0], 'TahoeIdpOAuth2 goes first'
 
-    plugin_settings(settings)
+    lms_production.plugin_settings(settings)
     assert settings.THIRD_PARTY_AUTH_BACKENDS.count(backend_path) == 1, 'adds only one instance'
 
 
-def test_authentication_backend_settings(settings):
+def test_cms_authentication_backend_settings(settings):
     """
     Test settings third party auth backends.
     """
     settings.AUTHENTICATION_BACKENDS = ['some_other_backend']
     backend_path = 'tahoe_idp.magiclink_backends.MagicLinkBackend'
 
-    plugin_settings(settings)
+    cms_production.plugin_settings(settings)
     assert backend_path == settings.AUTHENTICATION_BACKENDS[0], 'MagicLinkBackend goes first'
 
-    plugin_settings(settings)
+    cms_production.plugin_settings(settings)
     assert settings.AUTHENTICATION_BACKENDS.count(backend_path) == 1, 'add only one instance'
 
 
@@ -52,27 +56,27 @@ def test_authentication_backend_settings(settings):
         'message': '"MAGICLINK_LOGIN_REQUEST_TIME_LIMIT" must be an integer',
     },
 ])
-def test_wrong_settings(settings, invalid_test_case):
+def test_wrong_magiclink_settings(settings, invalid_test_case):
     """
     Tests a couple of bad configuration to ensure proper error messages are raised.
     """
     setattr(settings, invalid_test_case['name'], invalid_test_case['value'])
 
     with pytest.raises(ImproperlyConfigured, match=invalid_test_case['message']):
-        plugin_settings(settings)
+        common_production.magiclink_settings(settings)
 
 
 def test_token_length_configs(settings):
     """
     Ensure MAGICLINK_TOKEN_LENGTH is validated for security.
     """
-    plugin_settings(settings)
+    common_production.magiclink_settings(settings)
     assert settings.MAGICLINK_TOKEN_LENGTH == 50, 'default to 50'
 
     settings.MAGICLINK_TOKEN_LENGTH = 19
-    plugin_settings(settings)
+    common_production.magiclink_settings(settings)
     assert settings.MAGICLINK_TOKEN_LENGTH == 20, 'do not allow less than 20'
 
     settings.MAGICLINK_TOKEN_LENGTH = 60
-    plugin_settings(settings)
+    common_production.magiclink_settings(settings)
     assert settings.MAGICLINK_TOKEN_LENGTH == 60, 'allow setting any large value'


### PR DESCRIPTION
fixes:

```
settings_func(settings_module)", "  File \"/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/tahoe_idp/settings/production.py\", line 60, in plugin_settings", "    if tahoe_idp_backend not in settings.THIRD_PARTY_AUTH_BACKENDS:", "AttributeError: module 'cms.envs.production' has no attribute 'THIRD_PARTY_AUTH_BACKENDS'"], "stdout": "", "stdout_lines": []}
```