### PR TITLE
Fix THIRD_PARTY_AUTH_BACKENDS not found

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -136,9 +136,6 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
-THIRD_PARTY_AUTH_BACKENDS = [
-    "tahoe_idp.backend.TahoeIdpOAuth2",
-]
 
 LOGIN_URL = "/login/tahoe-idp"
 

--- a/tahoe_idp/__init__.py
+++ b/tahoe_idp/__init__.py
@@ -4,4 +4,4 @@ tahoe_idp initialization module
 
 # Increase this version by 1 after every backward-incompatible
 # change in the exported data format
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/tahoe_idp/settings/lms_production.py
+++ b/tahoe_idp/settings/lms_production.py
@@ -10,5 +10,5 @@ def plugin_settings(settings):
 
     # Add the Social / ThirdPartyAuth backend
     tahoe_idp_backend = 'tahoe_idp.backend.TahoeIdpOAuth2'
-    if tahoe_idp_backend not in settings.THIRD_PARTY_AUTH_BACKENDS:
-        settings.THIRD_PARTY_AUTH_BACKENDS.insert(0, tahoe_idp_backend)
+    if tahoe_idp_backend not in settings.AUTHENTICATION_BACKENDS:
+        settings.AUTHENTICATION_BACKENDS.insert(0, tahoe_idp_backend)

--- a/tahoe_idp/tests/test_openedx_settings.py
+++ b/tahoe_idp/tests/test_openedx_settings.py
@@ -15,14 +15,14 @@ def test_lms_tpa_backend_settings(settings):
     """
     Test settings third party auth backends.
     """
-    settings.THIRD_PARTY_AUTH_BACKENDS = ['dummy_backend']
+    settings.AUTHENTICATION_BACKENDS = ['dummy_backend']
     lms_production.plugin_settings(settings)
 
     backend_path = 'tahoe_idp.backend.TahoeIdpOAuth2'
-    assert backend_path == settings.THIRD_PARTY_AUTH_BACKENDS[0], 'TahoeIdpOAuth2 goes first'
+    assert backend_path == settings.AUTHENTICATION_BACKENDS[0], 'TahoeIdpOAuth2 goes first'
 
     lms_production.plugin_settings(settings)
-    assert settings.THIRD_PARTY_AUTH_BACKENDS.count(backend_path) == 1, 'adds only one instance'
+    assert settings.AUTHENTICATION_BACKENDS.count(backend_path) == 1, 'adds only one instance'
 
 
 def test_cms_authentication_backend_settings(settings):


### PR DESCRIPTION
## Change description

The plugin is failing because `THIRD_PARTY_AUTH_BACKENDS` is not always added and recognized when `plugin_settings` is called. This PR is to fix the issue by using `AUTHENTICATION_BACKENDS` directly since `AUTHENTICATION_BACKENDS` is actually loading the contents of `THIRD_PARTY_AUTH_BACKENDS` before importing plugins

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
