### PR TITLE
Retry IdP User API if no username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2.1.2 - 2023-01-02
+## 2.3.0 - 2023-04-19
+ - Support retries to IdP API to get username
+
+## 2.2.0 - 2023-01-02
  - Support for `idp_hint` URL parameter
 
 ## 2.1.0 - 2022-09-23

--- a/tahoe_idp/__init__.py
+++ b/tahoe_idp/__init__.py
@@ -4,4 +4,4 @@ tahoe_idp initialization module
 
 # Increase this version by 1 after every backward-incompatible
 # change in the exported data format
-__version__ = "2.2.0"
+__version__ = "2.3.0"


### PR DESCRIPTION
## Change description

Don't just set username to IdP user UUID if no username found. Retry configurable number of times, defaulting to 5. Log a warning and set to UUID if still no username. Deal with race conditions when no explicit user interaction step to set username. 

Requirements of our IdP force use of a webhook to set username in some circumstances, and that requires retries in some cases where the User is not yet persisted to their storage ... those delays can cause a race condition as we are as of yet not able to halt the auth flow into Tahoe until certain completion of setting the username.

See [ENG-80](https://appsembler.atlassian.net/browse/ENG-80) for more details .

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
