### PR TITLE
Sync first, last, full name to FusionAuth when saved in Open edX

### DIFF
--- a/tahoe_idp/apps.py
+++ b/tahoe_idp/apps.py
@@ -29,4 +29,37 @@ class TahoeIdpConfig(AppConfig):
                 },
             },
         },
+        'signals_config': {
+            'lms.djangoapp': {
+                'relative_path': 'receivers',
+                'receivers': [
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'django.contrib.auth.models.User',
+                    },
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                    },
+                ],
+            },
+            'cms.djangoapp': {
+                'relative_path': 'receivers',
+                'receivers': [
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'django.contrib.auth.models.User',
+                    },
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                    },
+                ],
+            },
+
+        },
     }

--- a/tahoe_idp/constants.py
+++ b/tahoe_idp/constants.py
@@ -3,3 +3,11 @@ Constants for the tahoe_idp package.
 """
 
 BACKEND_NAME = 'tahoe-idp'
+
+USER_FIELDS_TO_SYNC_OPENEDX_TO_IDP = {
+    'first_name': 'firstName',  # User
+    'last_name':  'lastName',  # User
+    # 'email': We don't sync on User save().  Instead, sync on confirmation of email change.
+    'name': 'fullName',  # UserProfile
+    # TODO:  Consider updating user.preferredLanguages from UserPreference model save
+}

--- a/tahoe_idp/receivers.py
+++ b/tahoe_idp/receivers.py
@@ -25,7 +25,7 @@ def user_sync_to_idp(sender, instance, **kwargs):
 
     for field in instance.fields:
         if field.name in fields_to_sync.keys():
-            user_update_dict[field.name] = fields_to_sync[field.name]
+            user_update_dict[fields_to_sync[field.name]] = getattr(instance, field.name)
 
     api.update_user(instance, {
             'user': user_update_dict

--- a/tahoe_idp/receivers.py
+++ b/tahoe_idp/receivers.py
@@ -17,7 +17,7 @@ def user_sync_to_idp(sender, instance, **kwargs):
 
     # Not necessary to sync if just created.  Already in sync.
     if kwargs['created']:
-        return False
+        return
 
     fields_to_sync = constants.USER_FIELDS_TO_SYNC_OPENEDX_TO_IDP
 
@@ -27,6 +27,7 @@ def user_sync_to_idp(sender, instance, **kwargs):
         if field.name in fields_to_sync.keys():
             user_update_dict[fields_to_sync[field.name]] = getattr(instance, field.name)
 
+    # will raise an Exception from raise_for_status if failure code
     api.update_user(instance, {
             'user': user_update_dict
         }

--- a/tahoe_idp/receivers.py
+++ b/tahoe_idp/receivers.py
@@ -1,0 +1,33 @@
+"""
+Signal receivers for tahoe-idp Django app.
+"""
+
+from . import api, constants
+
+
+def user_sync_to_idp(sender, instance, **kwargs):
+    """
+    Sync select User and UserProfile attributes back to the IdP.
+
+    Handles post_save Signals from User, UserProfile
+
+    We want to keep the user record in the IdP up to date with any changes made via
+    Account Settings, Django admin, or otherwise.
+    """
+
+    # Not necessary to sync if just created.  Already in sync.
+    if kwargs['created']:
+        return False
+
+    fields_to_sync = constants.USER_FIELDS_TO_SYNC_OPENEDX_TO_IDP
+
+    user_update_dict = {}
+
+    for field in instance.fields:
+        if field.name in fields_to_sync.keys():
+            user_update_dict[field.name] = fields_to_sync[field.name]
+
+    api.update_user(instance, {
+            'user': user_update_dict
+        }
+    )

--- a/tahoe_idp/tests/test_apps.py
+++ b/tahoe_idp/tests/test_apps.py
@@ -29,4 +29,36 @@ def test_app_config():
                 'app_name': 'tahoe_idp',
             },
         },
+        'signals_config': {
+            'lms.djangoapp': {
+                'relative_path': 'receivers',
+                'receivers': [
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'django.contrib.auth.models.User',
+                    },
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                    },
+                ],
+            },
+            'cms.djangoapp': {
+                'relative_path': 'receivers',
+                'receivers': [
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'django.contrib.auth.models.User',
+                    },
+                    {
+                        'receiver_func_name': 'user_sync_to_idp',
+                        'signal_path': 'django.db.models.signals.post_save',
+                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                    },
+                ],
+            },
+        }
     }, 'Should initiate the app as an Open edX plugin.'


### PR DESCRIPTION
## Change description

Add post_save Signal receivers on User, UserProfile to sync changes back to FusionAuth.  Installed receivers on LMS and CMS because the save could potentially occur in Django admin on Studio. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Fix for this issue where changes in Account Settings are being overwritten at next login due to user_details_force_sync in the TPA pipeline for tahoe-idp. 

https://appsembler.atlassian.net/browse/ENG-125

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
