### PR TITLE
Fix: change sender module path for student app signal

### DIFF
--- a/tahoe_idp/apps.py
+++ b/tahoe_idp/apps.py
@@ -41,7 +41,7 @@ class TahoeIdpConfig(AppConfig):
                     {
                         'receiver_func_name': 'user_sync_to_idp',
                         'signal_path': 'django.db.models.signals.post_save',
-                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                        'sender_path': 'student.models.UserProfile',
                     },
                 ],
             },
@@ -56,7 +56,7 @@ class TahoeIdpConfig(AppConfig):
                     {
                         'receiver_func_name': 'user_sync_to_idp',
                         'signal_path': 'django.db.models.signals.post_save',
-                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                        'sender_path': 'student.models.UserProfile',
                     },
                 ],
             },

--- a/tahoe_idp/tests/test_apps.py
+++ b/tahoe_idp/tests/test_apps.py
@@ -41,7 +41,7 @@ def test_app_config():
                     {
                         'receiver_func_name': 'user_sync_to_idp',
                         'signal_path': 'django.db.models.signals.post_save',
-                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                        'sender_path': 'student.models.UserProfile',
                     },
                 ],
             },
@@ -56,7 +56,7 @@ def test_app_config():
                     {
                         'receiver_func_name': 'user_sync_to_idp',
                         'signal_path': 'django.db.models.signals.post_save',
-                        'sender_path': 'common.djangoapps.student.models.UserProfile',
+                        'sender_path': 'student.models.UserProfile',
                     },
                 ],
             },


### PR DESCRIPTION
## Change description

My import wasn't working properly, Juniper still uses shortened `student` and not `common.djangoapps.student` .

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-125

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
