### PR TITLE
Catch exceptions for non idp users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.5.0 - 2023-06-29
+ - Catch exceptions trying to get a tahoe idp uid for users
+
 ## 2.4.4 - 2023-06-28
  - Fix user_sync_to_idp receiver for UserProfile
 

--- a/tahoe_idp/__init__.py
+++ b/tahoe_idp/__init__.py
@@ -4,4 +4,4 @@ tahoe_idp initialization module
 
 # Increase this version by 1 after every backward-incompatible
 # change in the exported data format
-__version__ = "2.4.4"
+__version__ = "2.5.0"

--- a/tahoe_idp/api.py
+++ b/tahoe_idp/api.py
@@ -75,7 +75,7 @@ def get_tahoe_idp_id_by_user(user):
         return social_auth_entry.uid
     except UserSocialAuth.DoesNotExist:
         # should only be an internal Appsembler admin user that was not migrated to IdP
-        log.warn(
+        log.warning(
             'Could not find tahoe IdP id: No UserSocialAuth record connecting {} to Tahoe IdP.'.format(user.username)
             )
         return None

--- a/tahoe_idp/tests/test_apis.py
+++ b/tahoe_idp/tests/test_apis.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, User
-from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
+from django.core.exceptions import MultipleObjectsReturned
 from requests import HTTPError
 from social_django.models import UserSocialAuth
 from unittest.mock import patch
@@ -118,8 +118,7 @@ def test_get_tahoe_idp_id_by_user_validation():
         get_tahoe_idp_id_by_user(user=AnonymousUser())
 
     user_without_idp_id = user_factory()
-    with pytest.raises(ObjectDoesNotExist):  # Should fail for malformed data
-        get_tahoe_idp_id_by_user(user=user_without_idp_id)
+    assert get_tahoe_idp_id_by_user(user=user_without_idp_id) is None, "Missing IdP Id should return None not error"
 
 
 def test_get_tahoe_idp_id_by_user_two_idp_ids():


### PR DESCRIPTION
## Change description

There can be a few User objects that don't have a matching UserSocialAuth for the IdP.  Catch exceptions querying for these and stop processing user update, etc. that rely on these.  Log a warning.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-125

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
