### PR TITLE
Allow user patch API 404 exceptions for superusers.

### DIFF
--- a/tahoe_idp/api.py
+++ b/tahoe_idp/api.py
@@ -12,9 +12,11 @@ External Python API helpers goes here.
  * For breaking changes, new functions should be created
 """
 
+import contextlib
 from datetime import datetime
 import logging
 import pytz
+from requests import exceptions as requests_exceptions
 from social_django.models import UserSocialAuth
 
 from urllib.parse import urlencode
@@ -24,6 +26,21 @@ from . import helpers
 
 
 log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def with_user_api_allowed_error_conditions(user):
+    """API function context manager to handle allowable error conditions."""
+
+    try:
+        yield
+    except requests_exceptions.HTTPError:
+        # Superusers may be associated with Tenants other than the one
+        # matching the domain in the request context.
+        if user.is_superuser:
+            log.info('Catching 404 from IdP for Tahoe superuser {}'.format(user.username))
+        else:
+            raise
 
 
 def request_password_reset(email):
@@ -92,12 +109,13 @@ def update_user(user, properties):
     if idp_user_id is None:
         return
 
-    client_response = api_client.patch_user(
-        user_id=idp_user_id,
-        request=properties,
-    )
-    http_response = helpers.get_successful_fusion_auth_http_response(client_response)
-    return http_response
+    with with_user_api_allowed_error_conditions(user):
+        client_response = api_client.patch_user(
+            user_id=idp_user_id,
+            request=properties,
+        )
+        http_response = helpers.get_successful_fusion_auth_http_response(client_response)
+        return http_response
 
 
 def update_user_email(user, email, set_email_as_verified=False):


### PR DESCRIPTION

## Change description

Catch, log, allow 404s from IdP when updating Django superusers.
Addresses issue with Appsembler superuser users who are associated with a different Tenant than the one associated with the domain in the URL being browsed.  Helps keep from having to proliferate a ton of admin accounts just to match with each customer Tenant.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-178

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
