### PR TITLE
Override auth_extra_arguments to remove None loginId values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.6.0 - 2023-08-23
+ - Allow use of `loginId` as social-core AUTH_EXTRA_ARGUMENTS.  Pass to Idp if present, remove if None.
+
 ## 2.5.1 - 2023-07-03
  - Allow 404 to IdP user patch API for superusers
 

--- a/tahoe_idp/__init__.py
+++ b/tahoe_idp/__init__.py
@@ -4,4 +4,4 @@ tahoe_idp initialization module
 
 # Increase this version by 1 after every backward-incompatible
 # change in the exported data format
-__version__ = "2.5.1"
+__version__ = "2.6.0"

--- a/tahoe_idp/backend.py
+++ b/tahoe_idp/backend.py
@@ -58,6 +58,19 @@ class TahoeIdpOAuth2(BaseOAuth2):
             params["idp_hint"] = default_idp_hint
         return params
 
+    def auth_extra_arguments(self):
+        """
+        Override the parent class' `auth_extra_arguments` to remove blank`loginId` args.
+        loginId is defined as an extra arg via SOCIAL_AUTH_TAHOE_IDP_AUTH_EXTRA_ARGUMENTS in settings.
+        If auth request was initiated with a queryString value loginId, pass it through to FusionAuth.
+        If not, remove the loginId arg from the auth request.
+        loginId can be used in FusionAuth templates to pre-populate the username field in the login form.
+        """
+        extra_args = super().auth_extra_arguments()
+        if extra_args.get("loginId", "") is None:
+            del extra_args["loginId"]
+        return extra_args
+
     def get_key_and_secret(self):
         """Return tuple with Consumer Key and Consumer Secret for current
         service provider. Must return (key, secret), order *must* be respected.

--- a/tahoe_idp/helpers.py
+++ b/tahoe_idp/helpers.py
@@ -98,7 +98,7 @@ def get_successful_fusion_auth_http_response(fa_response):
 
 def get_key_and_secret():
     """
-    Return tuple with Consumer Key and Consumer Secret for Tahoe IdP OAuth client.
+    Return dict with Consumer Key and Consumer Secret for Tahoe IdP OAuth client.
     """
     fail_if_tahoe_idp_not_enabled()
     key = config_client_api.get_admin_value('TAHOE_IDP_CLIENT_ID')


### PR DESCRIPTION
## Change description

Allows usage of `loginId` as a querystring param to pass through to FusionAuth.  `loginId` if present should be an email address, and will prepopulate the username field on hosted login forms.  This change ensures that a `None` default for loginId will be dropped instead of passed as the string "None".  

`loginId` should be defined via settings, in `SOCIAL_AUTH_TAHOE_IDP_AUTH_EXTRA_ARGUMENTS` with a default of None, for example in, https://github.com/appsembler/edx-configs/pull/1577

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-195

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
